### PR TITLE
fix ICE detrickling

### DIFF
--- a/app.js
+++ b/app.js
@@ -274,8 +274,8 @@ function handleEvent(request, context) {
 
             var candidateEvents = prematureCandidatesForCall[event.content.call_id] || [];
             var candidates = [];
-            candidateEvents.forEach(function(event) {
-                event.content.candidates.forEach(function(cand) {
+            candidateEvents.forEach(function(candidateEvent) {
+                candidateEvent.content.candidates.forEach(function(cand) {
                     candidates.push(cand);
                 });
             });

--- a/app.js
+++ b/app.js
@@ -307,7 +307,7 @@ function handleEvent(request, context) {
             prematureCandidatesForCall[event.content.call_id] =
                 prematureCandidatesForCall[event.content.call_id] || [];
             prematureCandidatesForCall[event.content.call_id].push(event);
-            return Promise.reject("Received candidates for unknown call");
+            return Promise.reject("Received and queued candidates for unknown call");
         }
         event.content.candidates.forEach(function(cand) {
             matrixSide.candidates.push(cand);

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -97,26 +97,19 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
     // depending on whether we've received just RTP or RTP+RTCP)
     var stats = [];
 
-    // create empty stats blocks where we expect to see candidates so we can
-    // spot if candidates are entirely missing...
-    for (var i = 0; i < matrixSide.offer.match(/^m=/mg).length; i++) {
-        stats[i] = {};
-    }
-
     // pre-parse the SDP invite
     // XXX: this should probably be combined with the later SDP parsing
     var mLineIndex = 0;
     var mLineIndexByMid = {};
     matrixSide.offer = matrixSide.offer.split("\r\n").map(function(line) {
         if (line.indexOf("m=") === 0) {
-            // create an empty stats block so we spot any missing candidates
+            // create empty stats blocks where we expect to see candidates so we can
+            // spot if candidates are entirely missing...
             stats[mLineIndex] = {};
             mLineIndex++;
         }
-        // work out the mLineIndexes of our mIds we have, in case we
-        // need to manipulate candidates who have no sdpMLineIndex
-        // given all the stuff below operates in terms of mLineIndexes
-        // rather than mIds
+        // work out a mapping from mIds to mLineIndexes, in case we
+        // need to manipulate candidates who have no sdpMLineIndex.
         var m = line.match(/^a=mid:(.*)/); // matching something like a=mid:sdparta_0
         if (m) {
             mLineIndexByMid[m[1]] = mLineIndex;

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -154,7 +154,8 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
         if (!stat.hasSrflx && !stat.hasRelay) enoughCandidates = false;
 
         // If we see gaps in the candidate component-id sequences then we should
-        // definitely hold off until we receive the missing candidates...
+        // definitely hold off until we receive the missing candidates, otherwise
+        // freeswitch has been known to segfault
 
         Object.keys(stat.componentIdSumByFoundation).forEach(function(foundation) {
             // sum must be a triangular number

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -96,6 +96,13 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
     // and sum the component IDs for each foundation (which should sum to 1 or 3
     // depending on whether we've received just RTP or RTP+RTCP)
     var stats = [];
+
+    // create empty stats blocks where we expect to see candidates so we can
+    // spot if candidates are entirely missing...
+    for (var i = 0; i < matrixSide.offer.match(/^m=/mg).length; i++) {
+        stats[i] = {};
+    }
+
     for (var i = 0; i < matrixSide.candidates.length; i++) {
         var c = matrixSide.candidates[i];
         if (!c.candidate) { continue; }

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -157,7 +157,10 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
                 stats[mLineIndex].componentIdSumByFoundation || {};
             stats[mLineIndex].componentIdSumByFoundation[foundation] =
                 stats[mLineIndex].componentIdSumByFoundation[foundation] || 0;
-            stats[mLineIndex].componentIdSumByFoundation[foundation] += componentId;
+            // N.B. we actually logical-OR rather than add the components
+            // as apparently it's valid to have some candidates with the same
+            // foundation and component ID...
+            stats[mLineIndex].componentIdSumByFoundation[foundation] |= componentId;
         }
         else {
             console.error("Can't parse candidate: " + c.candidate);

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -101,7 +101,7 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
     // XXX: this should probably be combined with the later SDP parsing
     var mLineIndex = 0;
     var mLineIndexByMid = {};
-    matrixSide.offer = matrixSide.offer.split("\r\n").map(function(line) {
+    matrixSide.offer.split("\r\n").forEach(function(line) {
         if (line.indexOf("m=") === 0) {
             // create empty stats blocks where we expect to see candidates so we can
             // spot if candidates are entirely missing...
@@ -163,7 +163,7 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
     }
 
     var enoughCandidates = true; // start off optimistic...
-    stats.forEach(function(stat) {
+    stats.forEach(function(stat, index) {
         // we've gathered enough candidates when've received srflx or relay candidates
         //
         // this works because if we've got a srflx, we will always be able to use it
@@ -179,8 +179,14 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
         // wrong (we've probably lost some m.call.candidate events) given every sane
         // ICE stack should generate host candidates.
 
-        if (!stat.hasHost) enoughCandidates = false;
-        if (!stat.hasSrflx && !stat.hasRelay) enoughCandidates = false;
+        if (!stat.hasHost) {            
+            enoughCandidates = false;
+            console.log("m= line " + index + " has no host candidates yet; waiting...");
+        }
+        if (!stat.hasSrflx && !stat.hasRelay) {
+            enoughCandidates = false;
+            console.log("m= line " + index + " has no srflx or relay candidates yet; waiting...");
+        }
 
         // If we see gaps in the candidate component-id sequences then we should
         // definitely hold off until we receive the missing candidates, otherwise
@@ -192,7 +198,10 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
             // will normally be 3 (RTP+RTCP) or 1 (just RTP, which is unlikely but
             // possible given any sensible WebRTC stack will speak RTCP)
             var sum = stat.componentIdSumByFoundation[foundation];
-            if (sum != 3 && sum != 1) enoughCandidates = false;
+            if (sum != 3 && sum != 1) {
+                enoughCandidates = false;
+                console.log("m= line " + index + " has missing components for foundation " + foundation + "; waiting...");
+            }
         });
     });
 

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -103,6 +103,26 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
         stats[i] = {};
     }
 
+    // pre-parse the SDP invite
+    // XXX: this should probably be combined with the later SDP parsing
+    var mLineIndex = 0;
+    var mLineIndexByMid = {};
+    matrixSide.offer = matrixSide.offer.split("\r\n").map(function(line) {
+        if (line.indexOf("m=") === 0) {
+            // create an empty stats block so we spot any missing candidates
+            stats[mLineIndex] = {};
+            mLineIndex++;
+        }
+        // work out the mLineIndexes of our mIds we have, in case we
+        // need to manipulate candidates who have no sdpMLineIndex
+        // given all the stuff below operates in terms of mLineIndexes
+        // rather than mIds
+        var m = line.match(/^a=mid:(.*)/); // matching something like a=mid:sdparta_0
+        if (m) {
+            mLineIndexByMid[m[1]] = mLineIndex;
+        }
+    });
+    
     for (var i = 0; i < matrixSide.candidates.length; i++) {
         var c = matrixSide.candidates[i];
         if (!c.candidate) { continue; }
@@ -112,15 +132,12 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
             mLineIndex = c.sdpMLineIndex;
         }
         else {
-            // hack: synthesise an mLineIndex based on heuristics
-            if (c.sdpMid === 'audio') {
-                mLineIndex = 0;
-            }
-            else if (c.sdpMid === 'video') {
-                mLineIndex = 1;
+            if (mLineIndexByMid[c.sdpMid] !== undefined) {
+                mLineIndex = mLineIndexByMid[c.sdpMid];
             }
             else {
-                mLineIndex = 0; // this is probably wrong though.
+                console.error("Can't find a m= line for candidate; ignoring: " + c.candidate);
+                continue;
             }
         }
         stats[mLineIndex] = stats[mLineIndex] || {};
@@ -133,11 +150,19 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
         if (c.candidate.indexOf("typ relay") !== -1) {
             stats[mLineIndex].hasRelay = 1;   
         }
+
+        // match the <foundation> and <component-id> of the candidate,
+        // in order to check we don't have any gaps in the component-id
+        // sequence for each foundation.
+        //
+        // e.g. "candidate:0 1 UDP 2122252543 131.254.15.55 53897 typ host"
         var m = c.candidate.match(/^candidate:(.*?) (.*?) /);
         if (m) {
+            var foundation = m[1];
+            var componentId = parseInt(m[2]);
             stats[mLineIndex].componentIdSumByFoundation =
                 stats[mLineIndex].componentIdSumByFoundation || {};
-            stats[mLineIndex].componentIdSumByFoundation[m[1]] += m[2];
+            stats[mLineIndex].componentIdSumByFoundation[foundation] += componentId;
         }
         else {
             console.error("Can't parse candidate: " + c.candidate);
@@ -156,6 +181,10 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
         // Similarly, if we've seen a relay candidate (which are typically the slowest
         // to set up and last to arrive), we know that will always work too, so we don't
         // need to wait for any others.
+        //
+        // Meanwhile if we haven't seen any host candidates then something has gone very
+        // wrong (we've probably lost some m.call.candidate events) given every sane
+        // ICE stack should generate host candidates.
 
         if (!stat.hasHost) enoughCandidates = false;
         if (!stat.hasSrflx && !stat.hasRelay) enoughCandidates = false;
@@ -165,9 +194,12 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
         // freeswitch has been known to segfault
 
         Object.keys(stat.componentIdSumByFoundation).forEach(function(foundation) {
-            // sum must be a triangular number
+            // sum must be a triangular number.
+            // in practice webrtc only ever uses RTP (1) and RTCP (2), so the sum
+            // will normally be 3 (RTP+RTCP) or 1 (just RTP, which is unlikely but
+            // possible given any sensible WebRTC stack will speak RTCP)
             var sum = stat.componentIdSumByFoundation[foundation];
-            if (sum != 1 && sum != 3) enoughCandidates = false;
+            if (sum != 3 && sum != 1) enoughCandidates = false;
         });
     });
 
@@ -246,6 +278,15 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
                 // insert candidate f.e. m= type (e.g. audio)
                 // This will repeatedly insert the candidate for m= blocks with
                 // the same type (unconfirmed if this is the 'right' thing to do)
+
+                // FIXME: this is *NOT* the right thing to do.  The sdpMid line
+                // describes the ID of the m= line we're targeting - e.g.
+                // Firefox specifies a=mid:sdparta_0, and so the cand.sdpMid
+                // is 'sdparta_0'.  This has nothing to do with 'audio'
+                // and 'video' strings.
+                //
+                // The implementation below is completely broken, but leaving it
+                // in for now in case anything is depending on that brokenness...
                 line = "a=" + cand.candidate + "\r\n" + line;
                 console.log(
                     "Inserted candidate %s at m= type %s",

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -90,17 +90,81 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
     if (matrixSide.candidates.length === 0) { return Promise.resolve(); }
     var self = this;
 
-    var enoughCandidates = false;
+    // see if we've got enough candidates to detrickle correctly.
+    // we start off by gathering some stats on the candidates we have:
+    // splitting into media sections, do we have host/srflx/relay candidates yet?
+    // and sum the component IDs for each foundation (which should sum to 1 or 3
+    // depending on whether we've received just RTP or RTP+RTCP)
+    var stats = [];
     for (var i = 0; i < matrixSide.candidates.length; i++) {
         var c = matrixSide.candidates[i];
         if (!c.candidate) { continue; }
-        // got enough candidates when SDP has a srflx or relay candidate
-        if (c.candidate.indexOf("typ srflx") !== -1 ||
-                c.candidate.indexOf("typ relay") !== -1) {
-            enoughCandidates = true;
-            console.log("Gathered enough candidates for %s", matrixSide.mxCallId);
-            break; // bail early
+
+        var mLineIndex;
+        if (c.sdpMLineIndex !== undefined) {
+            mLineIndex = c.sdpMLineIndex;
         }
+        else {
+            // hack: synthesise an mLineIndex based on heuristics
+            if (c.sdpMid === 'audio') {
+                mLineIndex = 0;
+            }
+            else if (c.sdpMid === 'video') {
+                mLineIndex = 1;
+            }
+            else {
+                mLineIndex = 0; // this is probably wrong though.
+            }
+        }
+        stats[mLineIndex] = stats[mLineIndex] || {};
+        if (c.candidate.indexOf("typ host") !== -1) {
+            stats[mLineIndex].hasHost = 1;
+        }
+        if (c.candidate.indexOf("typ srflx") !== -1) {
+            stats[mLineIndex].hasSrflx = 1;
+        }
+        if (c.candidate.indexOf("typ relay") !== -1) {
+            stats[mLineIndex].hasRelay = 1;   
+        }
+        var m = c.candidate.match(/^candidate:(.*?) (.*?) /);
+        if (m) {
+            stats[mLineIndex].componentIdSumByFoundation =
+                stats[mLineIndex].componentIdSumByFoundation || {};
+            stats[mLineIndex].componentIdSumByFoundation[m[1]] += m[2];
+        }
+        else {
+            console.error("Can't parse candidate: " + c.candidate);
+        }
+    }
+
+    var enoughCandidates = true; // start off optimistic...
+    stats.forEach(function(stat) {
+        // we've gathered enough candidates when've received srflx or relay candidates
+        //
+        // this works because if we've got a srflx, we will always be able to use it
+        // given we know that the freeswitch isn't NATted - so if a NATted client
+        // is able to correctly discover a srflx candidate, it should also be able to
+        // talk through to FS.
+        //
+        // Similarly, if we've seen a relay candidate (which are typically the slowest
+        // to set up and last to arrive), we know that will always work too, so we don't
+        // need to wait for any others.
+
+        if (!stat.hasHost) enoughCandidates = false;
+        if (!stat.hasSrflx && !stat.hasRelay) enoughCandidates = false;
+
+        // If we see gaps in the candidate component-id sequences then we should
+        // definitely hold off until we receive the missing candidates...
+
+        Object.keys(stat.componentIdSumByFoundation).forEach(function(foundation) {
+            // sum must be a triangular number
+            var sum = stat.componentIdSumByFoundation[foundation];
+            if (sum != 1 && sum != 3) enoughCandidates = false;
+        });
+    });
+
+    if (enoughCandidates) {
+        console.log("Gathered enough candidates for %s", matrixSide.mxCallId);
     }
 
     if (!enoughCandidates && !force) { // don't send the invite just yet

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -200,7 +200,7 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
             var sum = stat.componentIdSumByFoundation[foundation];
             if (sum != 3 && sum != 1) {
                 enoughCandidates = false;
-                console.log("m= line " + index + " has missing components for foundation " + foundation + "; waiting...");
+                console.log("m= line " + index + " has missing components for foundation " + foundation + ", sum=" + sum + "; waiting...");
             }
         });
     });

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -274,23 +274,17 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
                     cand.candidate, cand.sdpMLineIndex
                 );
             }
-            else if (cand.sdpMid !== undefined && cand.sdpMid === mType) {
-                // insert candidate f.e. m= type (e.g. audio)
-                // This will repeatedly insert the candidate for m= blocks with
-                // the same type (unconfirmed if this is the 'right' thing to do)
+            else if (cand.sdpMid !== undefined &&
+                     mLineIndexByMid[cand.sdpMid] !== undefined) {
 
-                // FIXME: this is *NOT* the right thing to do.  The sdpMid line
-                // describes the ID of the m= line we're targeting - e.g.
-                // Firefox specifies a=mid:sdparta_0, and so the cand.sdpMid
-                // is 'sdparta_0'.  This has nothing to do with 'audio'
-                // and 'video' strings.
-                //
-                // The implementation below is completely broken, but leaving it
-                // in for now in case anything is depending on that brokenness...
+                var mLineIndex = mLineIndexByMid[cand.sdpMid];
+                if (mLineIndex !== mIndex) {
+                    return;
+                }
                 line = "a=" + cand.candidate + "\r\n" + line;
                 console.log(
-                    "Inserted candidate %s at m= type %s",
-                    cand.candidate, cand.sdpMid
+                    "Inserted candidate %s at m= with index %s calculated from mId %s",
+                    cand.candidate, mLineIndex, cand.sdpMid
                 );
             }
         });

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -155,6 +155,8 @@ VertoEndpoint.prototype.attemptInvite = function(vertoCall, matrixSide, force) {
             var componentId = parseInt(m[2]);
             stats[mLineIndex].componentIdSumByFoundation =
                 stats[mLineIndex].componentIdSumByFoundation || {};
+            stats[mLineIndex].componentIdSumByFoundation[foundation] =
+                stats[mLineIndex].componentIdSumByFoundation[foundation] || 0;
             stats[mLineIndex].componentIdSumByFoundation[foundation] += componentId;
         }
         else {


### PR DESCRIPTION
Handle out-of-order candidates, and to ensure we have sufficient candidates before proceeding with the call.

This hasn't been at all tested (even to compile) yet, as I'm expecting to fiddle with it on production first.  Before I do that, though, I wanted to get review of the general fix here.
